### PR TITLE
fix: prevent repeated PlaceholderAPI log spam

### DIFF
--- a/src/main/java/com/werchat/integration/papi/PAPIHolder.java
+++ b/src/main/java/com/werchat/integration/papi/PAPIHolder.java
@@ -1,0 +1,32 @@
+package com.werchat.integration.papi;
+
+import com.werchat.WerchatPlugin;
+
+/**
+ * Caches a single PAPIIntegration instance so the expansion is only
+ * registered (and logged) once, regardless of how many callers invoke
+ * {@link PAPIIntegration#register}.
+ */
+final class PAPIHolder {
+    private static volatile PAPIIntegration instance;
+
+    private PAPIHolder() {}
+
+    static PAPIIntegration getOrCreate(WerchatPlugin plugin) {
+        if (instance != null) {
+            return instance;
+        }
+        synchronized (PAPIHolder.class) {
+            if (instance != null) {
+                return instance;
+            }
+            try {
+                Class.forName("at.helpch.placeholderapi.PlaceholderAPI");
+                instance = new PAPIImplementation(plugin);
+            } catch (ClassNotFoundException ignored) {
+                // PlaceholderAPI not present — leave null
+            }
+            return instance;
+        }
+    }
+}

--- a/src/main/java/com/werchat/integration/papi/PAPIImplementation.java
+++ b/src/main/java/com/werchat/integration/papi/PAPIImplementation.java
@@ -57,7 +57,13 @@ public class PAPIImplementation implements PAPIIntegration {
                 }
 
                 WerchatExpansion expansion = new WerchatExpansion(plugin);
-                if (expansion.isRegistered() || expansion.register()) {
+                if (expansion.isRegistered()) {
+                    expansionRegistered = true;
+                    loggedRegistrationFailure = false;
+                    return;
+                }
+
+                if (expansion.register()) {
                     expansionRegistered = true;
                     loggedRegistrationFailure = false;
                     plugin.getLogger().at(Level.INFO).log("PlaceholderAPI integration enabled");

--- a/src/main/java/com/werchat/integration/papi/PAPIIntegration.java
+++ b/src/main/java/com/werchat/integration/papi/PAPIIntegration.java
@@ -9,12 +9,7 @@ import com.werchat.WerchatPlugin;
 public interface PAPIIntegration {
 
     static PAPIIntegration register(WerchatPlugin plugin) {
-        try {
-            Class.forName("at.helpch.placeholderapi.PlaceholderAPI");
-            return new PAPIImplementation(plugin);
-        } catch (ClassNotFoundException ignored) {
-            return null;
-        }
+        return PAPIHolder.getOrCreate(plugin);
     }
 
     String setPlaceholders(PlayerRef player, String text);


### PR DESCRIPTION
## Summary

- `PAPIIntegration.register()` created a new `PAPIImplementation` on every call, but it's called from 4 places (ChannelCommand, ChannelSettingsPage, ChatListener, ChannelManager)
- Each instance had its own `expansionRegistered` flag, so "PlaceholderAPI integration enabled" logged every time any of them was first triggered (e.g. on every `/ch` command)
- Added `PAPIHolder` singleton cache so only one instance exists and the message logs exactly once

## Test plan

- [ ] Start server with PlaceholderAPI installed
- [ ] Verify "PlaceholderAPI integration enabled" appears once in logs
- [ ] Run multiple `/ch` commands — confirm no repeated log messages
